### PR TITLE
Fixed xpath

### DIFF
--- a/genius.rb
+++ b/genius.rb
@@ -67,6 +67,6 @@ puts song.url
 doc = Nokogiri::HTML(open(song.url))
 
 file = File.open(filepath, 'w')
-doc.xpath("//*[contains(@class, 'lyrics_')]").each do |node|
+doc.xpath("//*[contains(@class, 'lyrics')]").each do |node|
    file.write( node.text )
 end

--- a/genius.rb
+++ b/genius.rb
@@ -67,6 +67,6 @@ puts song.url
 doc = Nokogiri::HTML(open(song.url))
 
 file = File.open(filepath, 'w')
-doc.xpath("//*[contains(@class, 'lyrics')]").each do |node|
+doc.xpath("//div[@class='lyrics'][not(contains(div/@class, 'u-xx_large_vertical_margins'))]").each do |node|
    file.write( node.text )
 end


### PR DESCRIPTION
It seems like Genius restructured their website, as referring  to the div class "lyrics_" results in empty lyrics files. Fixed the xpath accordingly and excluded an element containing irrelevant information ('More on Genius'). 